### PR TITLE
Fixed host connect template

### DIFF
--- a/lib/esx.rb
+++ b/lib/esx.rb
@@ -35,8 +35,9 @@ module ESX
     # Requires hostname/ip, username and password
     #
     # Host connection is insecure by default
-    def self.connect(host, user, password,  opts = {},insecure = true)
+   def self.connect(host, user, password,  insecure = true, opts = {})
       templates_dir = opts[:templates_dir] || "/vmfs/volumes/datastore1/esx-gem/templates"
+     
       vim = RbVmomi::VIM.connect :host => host, :user => user, :password => password, :insecure => insecure
       host = Host.new(host, user,password, :templates_dir => templates_dir)
       host.vim = vim

--- a/lib/esx.rb
+++ b/lib/esx.rb
@@ -35,9 +35,11 @@ module ESX
     # Requires hostname/ip, username and password
     #
     # Host connection is insecure by default
-    def self.connect(host, user, password, insecure=true)
+    def self.connect(host, user, password,  opts = {},insecure = true)
+      templates_dir = opts[:templates_dir] || "/vmfs/volumes/datastore1/esx-gem/templates"
+      print templates_dir + "\n"
       vim = RbVmomi::VIM.connect :host => host, :user => user, :password => password, :insecure => insecure
-      host = Host.new(host, user,password)
+      host = Host.new(host, user,password, :templates_dir => templates_dir)
       host.vim = vim
       host
     end

--- a/lib/esx.rb
+++ b/lib/esx.rb
@@ -6,7 +6,7 @@ require 'net/ssh'
 
 module ESX
 
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
   
   if !defined? Log or Log.nil?
     Log = Logger.new($stdout)

--- a/lib/esx.rb
+++ b/lib/esx.rb
@@ -37,7 +37,6 @@ module ESX
     # Host connection is insecure by default
     def self.connect(host, user, password,  opts = {},insecure = true)
       templates_dir = opts[:templates_dir] || "/vmfs/volumes/datastore1/esx-gem/templates"
-      print templates_dir + "\n"
       vim = RbVmomi::VIM.connect :host => host, :user => user, :password => password, :insecure => insecure
       host = Host.new(host, user,password, :templates_dir => templates_dir)
       host.vim = vim


### PR DESCRIPTION
Updated esx.rb - fixed def self.connect to allow template location prameter to be passed to the Host.new method. Previously the Host.new only had 3 parameters when using the connect method, added optional :templates_dir parameter so now there are 4
